### PR TITLE
Fixe l'encodage quand la reponse contient des accents

### DIFF
--- a/lib/ansible/modules/identity/sx5/sx5_sp_config_system.py
+++ b/lib/ansible/modules/identity/sx5/sx5_sp_config_system.py
@@ -964,7 +964,7 @@ class SpConfigSystem(object):
                 return None
             return response.json()
         try:
-            msg = msg + ' - ' + response.text
+            msg = msg + ' - ' + response.text.encode('utf-8')
         except Exception as e:
             pass
         raise SpConfigSystemError("code {code} - {msg} : {token}".format(


### PR DESCRIPTION
Corrige le message d'erreur lorsqu'il contient des accents